### PR TITLE
Do not hardcode 'en0'

### DIFF
--- a/widgets/scripts/wifi_status_script
+++ b/widgets/scripts/wifi_status_script
@@ -11,13 +11,14 @@ while read line; do
         rc="$?"
         if [ "$rc" -eq 0 ]; then
             currentservice="$sname"
+	    currentsdev="$sdev"
             break
         fi
     fi
 done <<< "$(echo "$services")"
 
 if [ -n "$currentservice" ] ; then
-    echo "$currentservice@$(networksetup -getairportnetwork en0 | cut -c 24-)@$(networksetup -getinfo "Apple USB Ethernet Adapter" | grep "IP address" | grep "\." | cut -c 13-)"
+    echo "$currentservice@$(networksetup -getairportnetwork $currentsdev | cut -c 24-)@$(networksetup -getinfo "Apple USB Ethernet Adapter" | grep "IP address" | grep "\." | cut -c 13-)"
 else
     >&1 echo "none@none@"
     exit 1


### PR DESCRIPTION
The script does not work correctly because the interface is hardcoded
as 'en0', but this is not always the interface of the active interface.
As a result, incorrect information was reported.