### PR TITLE
Fix for computers without batteries

### DIFF
--- a/widgets/status.coffee
+++ b/widgets/status.coffee
@@ -30,6 +30,11 @@ timeAndDate: (date, time) ->
 batteryStatus: (battery, state) ->
   #returns a formatted html string current battery percentage, a representative icon and adds a lighting bolt if the
   # battery is plugged in and charging
+
+  # If no battery exists, battery is only '%' character
+  if state == 'AC' and battery == "%"
+    return "<span class='green icon'></span>"
+
   batnum = parseInt(battery)
   if state == 'AC' and batnum >= 90
     return "<span class='charging white sicon'></span><span class='green icon '></span>&nbsp;<span class='white'>#{batnum}%</span>"


### PR DESCRIPTION
Without a battery, the current widget results in 'undefined' being
printed in the status bar. Instead, if a battery does not exist,
then just return a lightning bolt to show power with no percentage
remaining value displayed.